### PR TITLE
BugFix: Update Pitch not picking up new "danger" or new "gradeModifier" - Issue #1

### DIFF
--- a/components/editor/route/InfoEdit.vue
+++ b/components/editor/route/InfoEdit.vue
@@ -565,11 +565,12 @@ export default {
               //grade modifier doesn't match
               check = false;
             }
+
             if (
-              (this.routeList[this.panel].pitches[pi].danger &&
+              (this.routeState[this.panel].pitches[pi].danger &&
                 this.routeList[this.panel].pitches[pi].danger !==
                   this.routeState[this.panel].pitches[pi].danger) ||
-              (!this.routeList[this.panel].pitches[pi].danger &&
+              (!this.routeState[this.panel].pitches[pi].danger &&
                 this.routeList[this.panel].pitches[pi].danger &&
                 this.routeList[this.panel].pitches[pi].danger !== "")
             ) {
@@ -582,6 +583,7 @@ export default {
           }
         }
       }
+
       return pitchCheck;
     },
     routeCheck() {

--- a/store/editor.js
+++ b/store/editor.js
@@ -110,8 +110,19 @@ export const mutations = {
   },
   updateRoutes: (state, payload) => {
     state.routeStateEditor = []
+    const serializePitch = (pitch) => _.defaults(pitch, {
+        danger: undefined,
+        description: undefined,
+        grade: undefined,
+        gradeModifier: undefined
+      })
+
+    const serializeRoute = (route) => _.defaultsDeep(route, {
+        pitches: _.map(route.pitches, (p) => serializePitch(p))
+      })
+
     for (let i in payload) {
-      state.routeStateEditor.push(payload[i])
+      state.routeStateEditor.push(serializeRoute(payload[i]))
     }
   },
   updateSelectedRoute: (state, payload) => {

--- a/store/editor.js
+++ b/store/editor.js
@@ -109,20 +109,20 @@ export const mutations = {
     state.cragStateEditor.paths = payload.paths;
   },
   updateRoutes: (state, payload) => {
-    state.routeStateEditor = []
+    state.routeStateEditor = [];
     const serializePitch = (pitch) => _.defaults(pitch, {
         danger: undefined,
         description: undefined,
         grade: undefined,
         gradeModifier: undefined
-      })
+      });
 
     const serializeRoute = (route) => _.defaultsDeep(route, {
         pitches: _.map(route.pitches, (p) => serializePitch(p))
-      })
+      });
 
     for (let i in payload) {
-      state.routeStateEditor.push(serializeRoute(payload[i]))
+      state.routeStateEditor.push(serializeRoute(payload[i]));
     }
   },
   updateSelectedRoute: (state, payload) => {

--- a/store/editor.js
+++ b/store/editor.js
@@ -118,6 +118,11 @@ export const mutations = {
       });
 
     const serializeRoute = (route) => _.defaultsDeep(route, {
+        style: undefined,
+        description: undefined,
+        protection: undefined,
+        grade: undefined,
+        gradeModifier: undefined,
         pitches: _.map(route.pitches, (p) => serializePitch(p))
       });
 

--- a/store/filter.js
+++ b/store/filter.js
@@ -555,6 +555,7 @@ export const mutations = {
     // state.areaState = payload;
   },
   updateMapBounds: (state, payload) => {
+    console.log('UPDATE MAP BOUNDS')
     state.mapBounds = payload;
   },
   updateBoundsDisable: (state, payload) => {

--- a/store/filter.js
+++ b/store/filter.js
@@ -559,7 +559,6 @@ export const mutations = {
     // state.areaState = payload;
   },
   updateMapBounds: (state, payload) => {
-    console.log('UPDATE MAP BOUNDS')
     state.mapBounds = payload;
   },
   updateBoundsDisable: (state, payload) => {


### PR DESCRIPTION
It appears that `pitchCheck` was not being recomputed (and therefore the "update pitch" button was not becoming enabled) when updating fields that were not included in the existing data (i.e. properties of `routeList` whose corresponding properties did not exist in `routeState` were not reactive in this component when updating pitches).

Ensuring all relevant fields exist in the editor store's state in a serialization step solves the problem. Looks like this was already done for top-level fields, but needed to be added for `routeStateEditor`.

I only addressed `route.pitch` here, since that's what was described in the issue, but I'm happy to check on other places if you'd like. Or, if it feels appropriate, this could be done generally at a higher level.

Of course feel free to let me know if there's a different pattern you'd like to follow here or if these functions should live somewhere else, etc.

Fixes ClimbAssist/ClimbAssistUI#1