### PR TITLE
BugFix: Fix incorrect color on previously selected route - Issue #5

### DIFF
--- a/components/crag/Model.vue
+++ b/components/crag/Model.vue
@@ -817,7 +817,6 @@ export default {
       this.scene.add(this.group);
     },
     loadLines() {
-      console.log('load lines')
       this.linesGroup = new THREE.Group();
       for (let wkey in this.crag.walls) {
         for (let rkey in this.crag.walls[wkey].routes) {

--- a/components/crag/Model.vue
+++ b/components/crag/Model.vue
@@ -353,7 +353,6 @@ export default {
               }
               let activeObject = this.group.children[key];
               this.lastActiveObject = activeObject;
-              this.lastActive = this.activeRoute;
               activeObject.scale.set(
                 this.scaleFactor * 1.5,
                 this.scaleFactor * 1.5,
@@ -366,14 +365,14 @@ export default {
                 this.activeLine !== this.linesGroup.children[key]
               ) {
                 if (
-                  this.crag.walls[this.activeRoute.wall].routes[
-                    this.activeRoute.route
+                  this.crag.walls[this.lastActive.wall].routes[
+                    this.lastActive.route
                   ].style === "sport"
                 ) {
                   this.activeLine.material.color.set("#0000ff");
                 } else if (
-                  this.crag.walls[this.activeRoute.wall].routes[
-                    this.activeRoute.route
+                  this.crag.walls[this.lastActive.wall].routes[
+                    this.lastActive.route
                   ].style === "trad"
                 ) {
                   this.activeLine.material.color.set("#ff0000");
@@ -383,6 +382,7 @@ export default {
               }
               this.activeLine = this.linesGroup.children[key];
               this.activeLine.material.color.set("#40FF70");
+              this.lastActive = this.activeRoute;
 
               this.loadAnchors();
               return activeObject;
@@ -817,6 +817,7 @@ export default {
       this.scene.add(this.group);
     },
     loadLines() {
+      console.log('load lines')
       this.linesGroup = new THREE.Group();
       for (let wkey in this.crag.walls) {
         for (let rkey in this.crag.walls[wkey].routes) {


### PR DESCRIPTION
- don't update lastActive until after color reset - ensures that the correct color is reapplied to the previously selected route

Fixes ClimbAssist/ClimbAssistUI#5, where selecting a route of a different type caused the incorrect route type color to be applied to the previously selected route.